### PR TITLE
Set devices to direct on initialization

### DIFF
--- a/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
+++ b/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
@@ -71,6 +71,7 @@ namespace RGB.NET.Devices.OpenRGB
                     //if the device doesn't have a direct mode, don't add it
                     if (!device.Modes.Any(m => m.Name == "Direct") && !ForceAddAllDevices)
                         continue;
+                    openRgb.SetMode(i, 0);
 
                     OpenRGBUpdateQueue? updateQueue = new OpenRGBUpdateQueue(GetUpdateTrigger(), i, openRgb, device);
 


### PR DESCRIPTION
I had some direct capable devices soft-brick as Artemis was sending updates even when the mode on the device wasn't actually direct. I tried using SetCustomMode, but for some reason it didn't do anything