### PR TITLE
Add speaker device to RGBDevice mapping

### DIFF
--- a/RGB.NET.Devices.OpenRGB/Helper.cs
+++ b/RGB.NET.Devices.OpenRGB/Helper.cs
@@ -36,6 +36,7 @@ namespace RGB.NET.Devices.OpenRGB
             DeviceType.Mouse => RGBDeviceType.Mouse,
             DeviceType.Mousemat => RGBDeviceType.Mousepad,
             DeviceType.Headset => RGBDeviceType.Headset,
+            DeviceType.Speaker=>RGBDeviceType.Speaker,
             DeviceType.HeadsetStand => RGBDeviceType.HeadsetStand,
             _ => RGBDeviceType.Unknown
         };

--- a/RGB.NET.Devices.OpenRGB/Helper.cs
+++ b/RGB.NET.Devices.OpenRGB/Helper.cs
@@ -36,7 +36,7 @@ namespace RGB.NET.Devices.OpenRGB
             DeviceType.Mouse => RGBDeviceType.Mouse,
             DeviceType.Mousemat => RGBDeviceType.Mousepad,
             DeviceType.Headset => RGBDeviceType.Headset,
-            DeviceType.Speaker=>RGBDeviceType.Speaker,
+            DeviceType.Speaker => RGBDeviceType.Speaker,
             DeviceType.HeadsetStand => RGBDeviceType.HeadsetStand,
             _ => RGBDeviceType.Unknown
         };

--- a/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
+++ b/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
@@ -22,7 +22,7 @@ namespace RGB.NET.Devices.OpenRGB
 
         public bool ForceAddAllDevices { get; set; }
 
-        public RGBDeviceType PerZoneDeviceFlag { get; } = RGBDeviceType.LedStripe | RGBDeviceType.Mainboard;
+        public RGBDeviceType PerZoneDeviceFlag { get; } = RGBDeviceType.LedStripe | RGBDeviceType.Mainboard | RGBDeviceType.Speaker;
 
         #endregion
 


### PR DESCRIPTION
Allow Artemis to use Speaker devices.
Allow Artemis to see Speker devices as perzone devices.